### PR TITLE
Fixed broken fb modal on main page

### DIFF
--- a/src/utilities/facebook.js
+++ b/src/utilities/facebook.js
@@ -52,6 +52,8 @@ const addCalendarIcon = data => {
       .format("dddd")
       .toLowerCase();
     element.dayicon = `img/calendar/${weekday}.png`;
+    element.tag = "tag";
+    element.tag += element.link.slice(32, 48);
   });
   return data;
 };

--- a/src/utilities/facebook.test.js
+++ b/src/utilities/facebook.test.js
@@ -138,7 +138,6 @@ describe("function should get right icon from date", () => {
       date: "13.12.2018",
       time: "18:00-20:00",
       link: "https://www.facebook.com/events/1246693872156189",
-      id: "id1246693872156189",
       dayicon: "img/calendar/thursday.png"
     }
   ];
@@ -149,7 +148,6 @@ describe("function should get right icon from date", () => {
       date: "13.12.2018",
       time: "18:00-20:00",
       link: "https://www.facebook.com/events/1246693872156189",
-      id: "id1246693872156189",
       dayicon: "img/calendar/sunday.png"
     }
   ];

--- a/src/utilities/facebook.test.js
+++ b/src/utilities/facebook.test.js
@@ -138,6 +138,7 @@ describe("function should get right icon from date", () => {
       date: "13.12.2018",
       time: "18:00-20:00",
       link: "https://www.facebook.com/events/1246693872156189",
+      tag: "tag1246693872156189",
       dayicon: "img/calendar/thursday.png"
     }
   ];
@@ -148,6 +149,7 @@ describe("function should get right icon from date", () => {
       date: "13.12.2018",
       time: "18:00-20:00",
       link: "https://www.facebook.com/events/1246693872156189",
+      tag: "tag1246693872156189",
       dayicon: "img/calendar/sunday.png"
     }
   ];

--- a/src/views/partials/home/__snapshots__/event.test.js.snap
+++ b/src/views/partials/home/__snapshots__/event.test.js.snap
@@ -5,7 +5,7 @@ exports[`event.hbs should match the snapshot 1`] = `
   <div class=\\"media\\">
     <img class=\\"align-self-center mr-2\\" src=\\"img/calendar/sunday.png\\" />
     <div class=\\"media-body\\">
-      <a class=\\"lead\\" href=\\"#\\" data-toggle=\\"modal\\" data-target=\\"#seven\\">
+      <a class=\\"lead\\" href=\\"#\\" data-toggle=\\"modal\\" data-target=\\"#\\">
         Webkurs
       </a>
       <p class=\\"text-muted mb-0\\">13.12.2018</p>

--- a/src/views/partials/home/event.hbs
+++ b/src/views/partials/home/event.hbs
@@ -2,7 +2,7 @@
   <div class="media">
     <img class="align-self-center mr-2" src="{{ dayicon }}" />
     <div class="media-body">
-      <a class="lead" href="#" data-toggle="modal" data-target="#{{ id }}">
+      <a class="lead" href="#" data-toggle="modal" data-target="#{{ tag }}">
         {{ name }}
       </a>
       <p class="text-muted mb-0">{{ date }}</p>

--- a/src/views/partials/home/modal.hbs
+++ b/src/views/partials/home/modal.hbs
@@ -1,8 +1,8 @@
-<div class="modal fade" id="{{ id }}" tabindex="-1" role="dialog" aria-labelledby="{{ name }}" aria-hidden="true">
+<div class="modal fade" id="{{ tag }}" tabindex="-1" role="dialog" aria-labelledby="{{ name }}" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title text-dark" id="{{ id }}">
+        <h5 class="modal-title text-dark" id="{{ tag }}">
           {{ name }}
         </h5>
       </div>


### PR DESCRIPTION
Fixed broken fb modal on main page by re-adding "id" and renaming it to "tag" to avoid conflict with facebookImage (background image for 2nd home tab).

Other suggestions for renaming are welcome :wink: 