### PR TITLE
Error page height equals viewport size

### DIFF
--- a/src/views/error.hbs
+++ b/src/views/error.hbs
@@ -1,4 +1,4 @@
-<div class="container-fluid pl-0 pr-0 error-page">
+<div class="d-flex container-fluid pl-0 pr-0 error-page">
   <img class="img-fluid" src="/img/error_404.jpg" alt="foggy forest">
   <h1 class="centered">Page Not Found</h2>
 </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -64,6 +64,8 @@ main {
 }
 
 .error-page {
+  max-height: calc(100vh - 93px);
+  min-height: calc(100vh - 93px);
   position: relative;
   text-align: center;
   color: white;


### PR DESCRIPTION
This prevents the error page from overflowing