### PR TITLE
Remove deprecated prettier settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  "prettier.eslintIntegration": true,
-  "prettier.stylelintIntegration": true,
   "prettier.singleQuote": false,
   "prettier.trailingComma": "none",
   "prettier.endOfLine": "lf",


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
- remove deprecated settings in `settings.json`
```
"prettier.eslintIntegration": true,
"prettier.stylelintIntegration": true
```
- [documentation](https://github.com/prettier/prettier-vscode#linter-integration)
<!-- Why are these changes necessary? -->

**Why**:
- fix legacy options warning

<!-- How were these changes implemented? -->

<!-- Have you done all of these things?  -->

<!-- Do you have a screenshot?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

Fixes #236 <!-- # number of the issue -->

<!-- feel free to add additional comments -->
