### PR TITLE
Replace Termin with latest Podcast on main page

### DIFF
--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -54,15 +54,28 @@ const blog = (latestPost) => ({
   image: latestPost.imagelink,
 });
 
+const podcast = (latestVideoPost) => ({
+  badge: "Podcast",
+  title: latestVideoPost.title,
+  text: `${latestVideoPost.date} | ${latestVideoPost.author}`,
+  link: `/podcasts/${latestVideoPost.id}`,
+  image: `https://img.youtube.com/vi/${latestVideoPost.video_id}/0.jpg`,
+});
+
 router.get("/", async (req, res) => {
   const calendar = await cache.get("events.json", events.getEvents);
   const latestPost = await cache.get("blogs.json", database.latestPost);
+  const latestVideoPost = await cache.get(
+    "videos.json",
+    database.latestVideoPost
+  );
 
   const result = {
     calendar,
     ourValues: ourValues(req.cookies.locale),
     event: event(calendar),
     blog: blog(latestPost),
+    podcast: podcast(latestVideoPost),
   };
   res.render("home", result);
 });
@@ -70,6 +83,7 @@ router.get("/", async (req, res) => {
 router.get("/invalidate", async (req, res) => {
   await cache.invalidate("events.json", events.getEvents);
   await cache.invalidate("blogs.json", database.latestPost);
+  await cache.invalidate("videos.json", database.latestVideoPost);
 
   res.redirect("/");
 });

--- a/src/views/home.hbs
+++ b/src/views/home.hbs
@@ -35,7 +35,7 @@
       <div class="col-sm-12">
         <div class="card-deck text-center">
           {{> home/card ourValues}}
-          {{> home/cardModal event}}
+          {{> home/card podcast}}
           {{> home/card blog}}
         </div>
       </div>


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
- replaced the broken Termin card with a card of the latest Podcast on the main page

<!-- Why are these changes necessary? -->

**Why**:
- problems to access FB data and to display events

<!-- How were these changes implemented? -->

**How**:
- reused the structure of the Blog card
- kept the code for the Event card in case we get a new FB token

<!-- Have you done all of these things?  -->

<!-- Do you have a screenshot?  -->
![image](https://user-images.githubusercontent.com/34481945/94803369-792a2300-03e9-11eb-87c7-e3dc5aba4a32.png)


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Fixes #279 <!-- # number of the issue -->

<!-- feel free to add additional comments -->
