### PR TITLE
Hide calendar if no FB events available

### DIFF
--- a/src/views/home.hbs
+++ b/src/views/home.hbs
@@ -14,6 +14,7 @@
             {{{__ "common_subtitle"}}}
           </p>
         </div>
+        {{#if calendar.length}}
         <div class="col-sm-4">
           <div class="card bg-primary overflow-hidden">
             <p class="h5 card-header text-center">
@@ -27,6 +28,7 @@
             </ul>
           </div>
         </div>
+        {{/if}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
- hide calendar section on home page when no FB events available

<!-- Why are these changes necessary? -->

**Why**:
- currently no FB token available to access the events

<!-- How were these changes implemented? -->

**How**:
- use handlebar helper to check if calendar array has any items and display accordingly

<!-- Have you done all of these things?  -->

<!-- Do you have a screenshot?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Fixes #367 <!-- # number of the issue -->

<!-- feel free to add additional comments -->
