### PR TITLE
fix cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,3 +10,9 @@ jobs:
       # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v2
+      - name: Upload failing screenshot
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "https://die-lernwerkstatt.org",
   "supportFile": false,
   "pluginsFile": false,
-  "fixturesFolder": false
+  "fixturesFolder": false,
+  "chromeWebSecurity": false
 }

--- a/cypress/integration/home/footer.spec.js
+++ b/cypress/integration/home/footer.spec.js
@@ -9,40 +9,38 @@ describe("Footer links", () => {
     {
       link: "Mitmachen",
       href: "support",
-      title: "Mitmachen"
+      title: "Mitmachen",
     },
     {
       link: "Kontakt",
       href: "contact",
-      title: "Kontakt"
+      title: "Kontakt",
     },
     {
       link: "Abonnieren",
       href: "subscribe",
-      title: "Abonnieren"
+      title: "Abonnieren",
     },
     {
       link: "Partner",
       href: "partners",
-      title: "Partner"
+      title: "Partner",
     },
     {
       link: "Freunde",
       href: "friends",
-      title: "Befreundete Initiativen"
+      title: "Befreundete Initiativen",
     },
     {
       link: "Impressum",
       href: "imprint",
-      title: "Impressum"
-    }
+      title: "Impressum",
+    },
   ];
 
-  pages.forEach(page => {
+  pages.forEach((page) => {
     it(`should go to ${page.link}`, () => {
-      cy.get("footer .nav-link")
-        .contains(page.link)
-        .click();
+      cy.get("footer .nav-link").contains(page.link).click();
 
       cy.location("pathname").should("include", page.href);
 

--- a/cypress/integration/home/header.spec.js
+++ b/cypress/integration/home/header.spec.js
@@ -1,8 +1,26 @@
 /// <reference types="cypress" />
 
+function closeCookieBanner() {
+  cy.get(".osano-cm-window").contains("Accept").click();
+}
+
+describe("Cookie banner", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+it(`should save the cookie preferences`, () => {
+    closeCookieBanner();
+
+    cy.get(".osano-cm-window").should("not.be.visible");
+  });
+});
+
 describe("Header links", () => {
   beforeEach(() => {
     cy.visit("/").setCookie("locale", "de");
+
+    closeCookieBanner();
   });
 
   const pages = [

--- a/cypress/integration/home/header.spec.js
+++ b/cypress/integration/home/header.spec.js
@@ -1,26 +1,10 @@
 /// <reference types="cypress" />
 
-function closeCookieBanner() {
-  cy.get(".osano-cm-window").contains("Accept").click();
-}
-
-describe("Cookie banner", () => {
-  beforeEach(() => {
-    cy.visit("/");
-  });
-
-it(`should save the cookie preferences`, () => {
-    closeCookieBanner();
-
-    cy.get(".osano-cm-window").should("not.be.visible");
-  });
-});
-
 describe("Header links", () => {
   beforeEach(() => {
     cy.visit("/").setCookie("locale", "de");
 
-    closeCookieBanner();
+    cy.get(".osano-cm-window").contains("Accept").click();
   });
 
   const pages = [


### PR DESCRIPTION
**What**:

- fix cypress test for header

**Why**:

- the osano cookie banner covered the header and made the test fail

**How**:

- cypress clicks on the cookie banner to hide it before accessing the header

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Fixes #433 

<!-- feel free to add additional comments -->
