### PR TITLE
Update mapbox implementation

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,19 +1,21 @@
 const mymap = L.map("mapid").setView([52.49065, 13.44831], 16);
 
 L.tileLayer(
-  "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}",
+  "https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}",
   {
     attribution:
-      'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+      '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
+    tileSize: 512,
     maxZoom: 18,
-    id: "mapbox.streets",
+    zoomOffset: -1,
+    id: "mapbox/streets-v12",
     accessToken:
-      "pk.eyJ1Ijoic3Rhcm1hZXJrZXIiLCJhIjoiY2pqZjZhNDE1MGEyMTN2cXN2cHYyM3J1OCJ9.BhLnttNctRll0LVyaWqu2g"
+      "pk.eyJ1IjoibGVybndlcmtzdGF0dCIsImEiOiJjbHZlZTV4aGYwODB0MmlwcjZobTNvdXh0In0.eAgHJ3c0Yl5XahdyJQWcYQ",
   }
 ).addTo(mymap);
 
 const marker = L.marker([52.49065, 13.44831], {
   title: "Die Lernwerkstatt",
-  alt: "Die Lernwerkstatt"
+  alt: "Die Lernwerkstatt",
 }).addTo(mymap);
 marker.bindPopup("<b>Hallo!</b><br>Besuch uns mal!").openPopup();


### PR DESCRIPTION
Seems like the api we were using is deprecated, this update should bring the map back on the contact page. I also created a new account with the dev email address and updated the token. The old token has been connected to my personal account.

More details on the Mapbox migration:
https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/