### PR TITLE
Fix contact form

### DIFF
--- a/src/routes/contact.js
+++ b/src/routes/contact.js
@@ -20,6 +20,7 @@ router
     const mailOptions = {
       from: process.env.CONTACT_USER,
       to: process.env.CONTACT_RECEIVE,
+      replyTo: `${req.body.name} <${req.body.email}>`,
       subject: `Anfrage via Kontaktformular von ${req.body.name}`,
       text: `${req.body.name} (${req.body.email}) schreibt: ${req.body.message}`,
     };

--- a/src/routes/contact.js
+++ b/src/routes/contact.js
@@ -12,13 +12,13 @@ router
       host: process.env.CONTACT_HOST,
       port: process.env.CONTACT_PORT,
       auth: {
-        user: process.env.CONTACT_USER,
+        user: process.env.CONTACT_SENDER,
         pass: process.env.CONTACT_PASS,
       },
     });
 
     const mailOptions = {
-      from: `${req.body.name} <${req.body.email}>`,
+      from: process.env.CONTACT_USER,
       to: process.env.CONTACT_RECEIVE,
       subject: `Anfrage via Kontaktformular von ${req.body.name}`,
       text: `${req.body.name} (${req.body.email}) schreibt: ${req.body.message}`,


### PR DESCRIPTION
The contact form has not been working since we moved to DigitalOcean because by default SMTP port 25 is blocked. This should prevent the use of DigitalOcean domains to send out spam emails (see https://docs.digitalocean.com/support/why-is-smtp-blocked/).

The suggested workaround is to use [SendGrid](https://sendgrid.com/en-us). I've created an account with our dev address there and followed [these docs](https://docs.sendgrid.com/for-developers/sending-email/quickstart-nodejs) to set everything up.

I've already changed the env vars so this should work once the PR is merged. Let me know if there are any questions.

SendGrid requires `from`to be identical with the verified email address, so an additional `replyTo` field is necessary to actually reply to the person who sent the contact request via the form on the website.